### PR TITLE
Add bower package configuration and .editorconfig, apply formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+tab_width = 4
+charset = utf-8
+
+[{package.json,bower.json}]
+indent_style = space
+indent_size = 2

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "reveal_external",
+  "version": "1.0.0",
+  "description": "Plugin for reveal.js to import external sections.",
+  "homepage": "https://github.com/janschoepke/reveal_external#readme",
+  "license": "MIT",
+  "authors": [
+    "Jan Schoepke"
+  ],
+  "keywords": [
+    "reveal",
+    "external",
+    "xhr"
+  ],
+  "main": [
+    "src/external.js"
+  ],
+  "ignore": [
+    "**/.*",
+    "example/"
+  ]
+}

--- a/external/external.js
+++ b/external/external.js
@@ -13,10 +13,10 @@
  */
 
 (function(){
-    loadExternal(document);
+	loadExternal(document);
 
 	function updateSection(section, path) {
-        "use strict";
+		"use strict";
 
 		var xhr = new XMLHttpRequest();
 		var url = section.getAttribute( "data-external" );
@@ -56,21 +56,20 @@
 
 	}
 
-    function loadExternal(selector, path) {
-        "use strict";
+	function loadExternal(selector, path) {
+		"use strict";
 
-        var sections = selector.querySelectorAll( "[data-external]");
-        
-        path = typeof path === "undefined" ? "" : path;
+		var sections = selector.querySelectorAll( "[data-external]");
 
-        for( var i = 0; i < sections.length; i+=1 ) {
+		path = typeof path === "undefined" ? "" : path;
 
-            var section = sections[i];
+		for( var i = 0; i < sections.length; i+=1 ) {
 
-            if( section.getAttribute( "data-external" ).length ) {
+			var section = sections[i];
+
+			if( section.getAttribute( "data-external" ).length ) {
 				updateSection(section, path);
 			}
-        }
-        return;
-    }
+		}
+	}
 })();


### PR DESCRIPTION
Reveal.js itself is a Bower package. It makes it easier to install and update the plugins in an presentation.

external.js contained mixed indentation (tabs and spaces). The .editorconfig helps to avoid that - it is supported by a lot of editors/IDEs.